### PR TITLE
Only use native browser lazy loading

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt update && sudo apt install -y --no-install-recommends python3-setuptools
-        pip3 install --upgrade setuptools
+        pip3 install --upgrade setuptools==71.0.0
         pip3 install flake8 black
 
     - name: Lint Python
@@ -45,12 +45,12 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt update && sudo apt install -y --no-install-recommends python3-setuptools
-        pip3 install --upgrade setuptools
+        pip3 install --upgrade setuptools==71.0.0
         pip3 install coverage
 
     - name: Test Python
       run: python3 -m coverage run ./setup.py test
-      
+
   check-inclusive-naming:
     runs-on: ubuntu-latest
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+v1.4.1, 2024-10-30: Switch to using native lazyloading only (without lazysizes wrapping div)
 v1.3.1, 2020-09-24: Make e_sharpen optional
 v1.3.0, 2020-09-24: Add e_sharpen to images
 v1.2.0, 2020-07-24: Make height optional

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 A module to generate performant HTML image markup for images. The markup
 will:
 
-- Use [native lazyloading](https://addyosmani.com/blog/lazy-loading/) if it's available
-- Output markup compatible with [lazysizes `noscript` plugin](https://github.com/aFarkas/lazysizes/tree/gh-pages/plugins/noscript)
+- Use [native lazyloading](https://addyosmani.com/blog/lazy-loading/)
 - Explicitly define `width` and `height` attributes to avoid the page jumping effect
 - Prefix all image URLs with cloudinary CDN proxy URLs, to transform the image to the optimal size
 - Use predefined (2x) `srcset` break points for hidef screens
@@ -50,18 +49,6 @@ image_markup = image_template(
 ```
 
 However, the most common usage is to add it to Django or Flask template contexts, as an `image` function.
-
-### Add lazysizes
-
-At the time of writing, the `loading` attribute [is only natively supported](https://caniuse.com/#search=loading) in Chrome. Therefore we use [lazysizes](https://github.com/aFarkas/lazysizes) to enable loading in other browsers while still taking advantage of the native functionality when it's available.
-
-If `loading` is set to "lazy" (the default) we will output [the Markup](#generated-markup) in a format supported by [lazysizes](https://github.com/aFarkas/lazysizes), with the [`noscript`](https://github.com/aFarkas/lazysizes/tree/gh-pages/plugins/noscript) and [`native-loading`](https://github.com/aFarkas/lazysizes/tree/gh-pages/plugins/native-loading) plugins enabled.
-
-To support this in your site you need to add the following script to the `<head>` of each page, *above* any `<link>` attributes:
-
-``` html
-<script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>
-```
 
 ### Django usage
 
@@ -146,16 +133,6 @@ The output image markup will be e.g.:
     class="hero"
     id="openstack hero"
 />
-```
-
-If `loading` is set to "lazy" (the default), the output markup will be wrapped in markup for lazysizes support:
-
-``` html
-<div class="lazyload" data-noscript>
-  <noscript>
-    <img ...>
-  </noscript>
-</div>
 ```
 
 ## VS Code Snippet

--- a/canonicalwebteam/templates/image_template.html
+++ b/canonicalwebteam/templates/image_template.html
@@ -1,23 +1,15 @@
-{%- if loading == "lazy" %}
-<div class="lazyload" data-noscript>
-  <noscript>
-{%- endif %}
-    <img
-      src="https://res.cloudinary.com/canonical/image/fetch/{{ std_def_cloudinary_options }}/{{ url }}"
-      {%- if hi_def %}
-      srcset="https://res.cloudinary.com/canonical/image/fetch/{{ hi_def_cloudinary_options }}/{{ url }} 2x"
-      {%- endif %}
-      alt="{{ alt }}"
-      width="{{ width }}"
-      {%- if height %}
-      height="{{ height }}"
-      {%- endif %}
-      loading="{{ loading }}"
-      {%- for attr_name, attr_value in attrs.items() %}
-      {{ attr_name }}="{{ attr_value }}"
-      {%- endfor %}
-    />
-{%- if loading == "lazy" %}
-  </noscript>
-</div>
-{% endif %}
+<img
+  src="https://res.cloudinary.com/canonical/image/fetch/{{ std_def_cloudinary_options }}/{{ url }}"
+  {%- if hi_def %}
+  srcset="https://res.cloudinary.com/canonical/image/fetch/{{ hi_def_cloudinary_options }}/{{ url }} 2x"
+  {%- endif %}
+  alt="{{ alt }}"
+  width="{{ width }}"
+  {%- if height %}
+  height="{{ height }}"
+  {%- endif %}
+  loading="{{ loading }}"
+  {%- for attr_name, attr_value in attrs.items() %}
+  {{ attr_name }}="{{ attr_value }}"
+  {%- endfor %}
+/>

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="canonicalwebteam.image-template",
-    version="1.3.1",
+    version="1.4.1",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(


### PR DESCRIPTION
Fixes: https://github.com/canonical/canonicalwebteam.image-template/issues/60

Drive-by: workaround for failing python tests (pinning version of setuptools), to be properly addressed in #62


## QA

- make sure no wrapping div is added to lazyloaded images