### PR TITLE
fix: Pass 'c_limit' param to hi_def URL

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+v1.4.2, 2024-12-19: Add 'c_limit' to hi-def cloudinary urls
 v1.4.1, 2024-10-30: Switch to using native lazyloading only (without lazysizes wrapping div)
 v1.3.1, 2020-09-24: Make e_sharpen optional
 v1.3.0, 2020-09-24: Add e_sharpen to images

--- a/canonicalwebteam/templates/image_template.html
+++ b/canonicalwebteam/templates/image_template.html
@@ -1,7 +1,7 @@
 <img
   src="https://res.cloudinary.com/canonical/image/fetch/{{ std_def_cloudinary_options }}/{{ url }}"
   {%- if hi_def %}
-  srcset="https://res.cloudinary.com/canonical/image/fetch/{{ hi_def_cloudinary_options }}/{{ url }} 2x"
+  srcset="https://res.cloudinary.com/canonical/image/fetch/c_limit,{{ hi_def_cloudinary_options }}/{{ url }} 2x"
   {%- endif %}
   alt="{{ alt }}"
   width="{{ width }}"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="canonicalwebteam.image-template",
-    version="1.4.1",
+    version="1.4.2",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(


### PR DESCRIPTION
## Done

- Adds the 'c_limit' flag to the image width and height on hi-def image which limits the max width and height of the image to it's intrinsic width and height, [see docs](https://cloudinary.com/documentation/transformation_reference#c_limit). This is because the hi-def tag doubles the width and height, sometimes leading to the image size being set larger than the original image size, and making the quality worse

## QA 

- Open [the demo](https://canonical-com-1467.demos.haus/data/postgresql/what-is-postgresql) I set up on c.com that references this branch in it's requirements
- Compare the image quality to [production](https://canonical.com/data/postgresql/what-is-postgresql) and see they are the same