### PR TITLE
feat: Add optional 'fmt' (format) parameter

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+v1.5.0, 2025-02-05: Add optional 'fmt' parameter for defining the format
 v1.4.2, 2024-12-19: Add 'c_limit' to hi-def cloudinary urls
 v1.4.1, 2024-10-30: Switch to using native lazyloading only (without lazysizes wrapping div)
 v1.3.1, 2020-09-24: Make e_sharpen optional

--- a/canonicalwebteam/image_template/__init__.py
+++ b/canonicalwebteam/image_template/__init__.py
@@ -20,6 +20,7 @@ def image_template(
     fill=False,
     e_sharpen=False,
     loading="lazy",
+    fmt="auto",
     attrs={},
 ):
     """
@@ -32,7 +33,7 @@ def image_template(
     # https://cloudinary.com/documentation/image_transformations
 
     cloudinary_options = [
-        "f_auto",  # Auto choose format
+        "f_" + str(fmt),
         "q_auto",  # Auto optimise quality
         "fl_sanitize",  # Sanitize SVG content
     ]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="canonicalwebteam.image-template",
-    version="1.4.2",
+    version="1.5.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(


### PR DESCRIPTION
## Done

- Add optional 'fmt' parameter for defining the format. If nothing is passed it defaults to 'auto', the same as before. See [the docs](https://cloudinary.com/documentation/image_transformations#delivering_in_a_different_format) for some more info

## QA

- Check out [the demo](https://ubuntu-com-14713.demos.haus/) set up on u.com that uses this version of the image-template module
- Go to any of the full width images and check they are jpegs. The easiest way to do this is to to save the image and see the extension. Bonus point if you open the binary and check it starts with `FF D8`

