### PR TITLE
Support image attrs output

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ will:
 - `loading` (optional string, default: "lazy"): Set to ["auto" or "eager"](https://addyosmani.com/blog/lazy-loading/) to disable lazyloading
 - `fmt` (optional string, default: "auto"): Define the file format (e.g. `fmt="jpg"`)
 - `attrs` (optional dictionary): Extra `<img>` attributes (e.g. `class` or `id`) can be passed as additional arguments
+- `output_mode` (optional string, default: "html"): The output mode can be set to either `html` or `attrs`. If set to `atrrs`, the function will return an object with the image attributes instead of HTML markup.
 
 ## Usage
 

--- a/canonicalwebteam/templates/image_template.html
+++ b/canonicalwebteam/templates/image_template.html
@@ -1,7 +1,7 @@
 <img
-  src="https://res.cloudinary.com/canonical/image/fetch/{{ std_def_cloudinary_options }}/{{ url }}"
+  src="{{ src }}"
   {%- if hi_def %}
-  srcset="https://res.cloudinary.com/canonical/image/fetch/c_limit,{{ hi_def_cloudinary_options }}/{{ url }} 2x"
+  srcset="{{ srcset }}"
   {%- endif %}
   alt="{{ alt }}"
   width="{{ width }}"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="canonicalwebteam.image-template",
-    version="1.5.0",
+    version="1.6.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(

--- a/tests/test_image_template.py
+++ b/tests/test_image_template.py
@@ -15,6 +15,7 @@ non_asset_url = (
     "2018/10/Screenshot_from_2018-10-26_14-20-14.png"
 )
 non_hostname_url = "/static/images/Screenshot_from_2018-10-26_14-20-14.png"
+cloudinary_url_base = "https://res.cloudinary.com/canonical/image/fetch"
 
 
 class TestImageTemplate(unittest.TestCase):
@@ -128,6 +129,35 @@ class TestImageTemplate(unittest.TestCase):
 
         self.assertNotIn("height=", image)
         self.assertNotIn("h_auto", image)
+
+    def test_attrs_return(self):
+        image_attrs = {
+            "url": asset_url,
+            "alt": "test",
+            "width": 1920,
+            "height": 1080,
+            "loading": "lazy",
+            "hi_def": True,
+            "attrs": {},
+        }
+
+        expected_attrs = image_attrs.copy()
+        returned_attrs = image_template(**image_attrs, output_mode="attrs")
+
+        # consumed by src and srcset
+        del expected_attrs["url"]
+
+        expected_attrs["src"] = (
+            f"{cloudinary_url_base}/f_auto,q_auto,fl_sanitize,w_1920,h_1080"
+            f"/{asset_url}"
+        )
+
+        expected_attrs["srcset"] = (
+            f"{cloudinary_url_base}/c_limit,f_auto,q_auto,fl_sanitize,"
+            f"w_3840,h_2160/{asset_url} 2x"
+        )
+
+        self.assertEqual(expected_attrs, returned_attrs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a new parameter `output_mode` that, when set to `attrs`, returns the attributes that would be passed to the image tag, rather than the markup. 

This enables consuming code to construct the <img> element itself, allowing more control of the rendered image. For example, allowing a Jinja macro to set the classnames used by an image generated by this template.

Fixes https://github.com/canonical/vanilla-framework/pull/5503#discussion_r2152049162