### PR TITLE
fix:  Wordpress images on blogs are not rendered

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+v1.7.0, 2025-02-05: Encode urls to make sure wordpress images do not break
 v1.5.0, 2025-02-05: Add optional 'fmt' parameter for defining the format
 v1.4.2, 2024-12-19: Add 'c_limit' to hi-def cloudinary urls
 v1.4.1, 2024-10-30: Switch to using native lazyloading only (without lazysizes wrapping div)

--- a/canonicalwebteam/image_template/__init__.py
+++ b/canonicalwebteam/image_template/__init__.py
@@ -1,7 +1,7 @@
 # Standard library
 import os
 import sys
-from urllib.parse import urlparse
+from urllib.parse import quote, unquote, urlparse
 
 # Packages
 from jinja2 import Environment, FileSystemLoader
@@ -68,10 +68,20 @@ def image_template(
 
     std_def_cloudinary_attrs = ",".join(std_def_cloudinary_options)
     hi_def_cloudinary_attrs = ",".join(hi_def_cloudinary_options)
-    image_src = f"{cloudinary_url_base}/{std_def_cloudinary_attrs}/{url}"
+
+    # Decode the URL first to prevent double encoding
+    decoded_url = unquote(url)
+    encoded_url = quote(decoded_url, safe="")
+
+    image_src = (
+        f"{cloudinary_url_base}/"
+        f"{std_def_cloudinary_attrs}/"
+        f"{encoded_url}"
+    )
 
     image_srcset = (
-        f"{cloudinary_url_base}/c_limit," f"{hi_def_cloudinary_attrs}/{url} 2x"
+        f"{cloudinary_url_base}/c_limit,"
+        f"{hi_def_cloudinary_attrs}/{encoded_url} 2x"
     )
 
     image_attrs = {

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="canonicalwebteam.image-template",
-    version="1.6.0",
+    version="1.7.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(

--- a/tests/test_image_template.py
+++ b/tests/test_image_template.py
@@ -141,7 +141,7 @@ class TestImageTemplate(unittest.TestCase):
         }
 
         decoded_asset_url = unquote(asset_url)
-        encoded_asset_url = quote(decoded_asset_url, safe='')
+        encoded_asset_url = quote(decoded_asset_url, safe="")
 
         expected_attrs = image_attrs.copy()
         returned_attrs = image_template(**image_attrs, output_mode="attrs")

--- a/tests/test_image_template.py
+++ b/tests/test_image_template.py
@@ -3,13 +3,12 @@ import unittest
 
 # Local
 from canonicalwebteam import image_template
-from urllib.parse import quote
+from urllib.parse import quote, unquote
 
 
 asset_url = (
     "https://assets.ubuntu.com/" "v1/479958ed-vivid-hero-takeover-kylin.jpg"
 )
-encoded_asset_url = quote(asset_url)
 non_asset_url = (
     "https://dashboard.snapcraft.io/site_media/appmedia/"
     "2018/10/Screenshot_from_2018-10-26_14-20-14.png"
@@ -141,6 +140,9 @@ class TestImageTemplate(unittest.TestCase):
             "attrs": {},
         }
 
+        decoded_asset_url = unquote(asset_url)
+        encoded_asset_url = quote(decoded_asset_url, safe='')
+
         expected_attrs = image_attrs.copy()
         returned_attrs = image_template(**image_attrs, output_mode="attrs")
 
@@ -151,12 +153,12 @@ class TestImageTemplate(unittest.TestCase):
 
         expected_attrs["src"] = (
             f"{cloudinary_url_base}/f_auto,q_auto,fl_sanitize,w_1920,h_1080"
-            f"/{asset_url}"
+            f"/{encoded_asset_url}"
         )
 
         expected_attrs["srcset"] = (
             f"{cloudinary_url_base}/c_limit,f_auto,q_auto,fl_sanitize,"
-            f"w_3840,h_2160/{asset_url} 2x"
+            f"w_3840,h_2160/{encoded_asset_url} 2x"
         )
 
         self.assertEqual(expected_attrs, returned_attrs)


### PR DESCRIPTION
## Done

 - Encoded image url so wordpress images are rendered fine

## QA

- Checkout the [demo](https://ubuntu-com-15391.demos.haus/blog/linux-foundation-openstack)
- Scroll down and verify that images are visible in the blog
- Open random pages on https://ubuntu-com-15391.demos.haus/ and make sure no other images are breaking