### PR TITLE
feat: bypass cloudinary for optimized image formats

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+v1.9.0, 2025-09-01: Skip srcsets for SVG and use initial fmt for SVG, WEBP & AVIF
 v1.8.0, 2025-07-29: Optimized srcset widths for responsive images
 v1.7.0, 2025-02-05: Encode urls to make sure wordpress images do not break
 v1.5.0, 2025-02-05: Add optional 'fmt' parameter for defining the format

--- a/canonicalwebteam/image_template/__init__.py
+++ b/canonicalwebteam/image_template/__init__.py
@@ -105,22 +105,26 @@ def image_template(
         width_int = int(width)
         srcset = []
 
-        # Only generate srcset for images larger than 100px
-        if width_int > 100:
+        def create_srcset_url(width, options):
+            width_options = options.copy()
+            width_options.append(f"w_{width}")
+            width_attrs = ",".join(width_options)
+            return (
+                f"{cloudinary_url_base}/{width_attrs}/"
+                f"{encoded_url} {width}w"
+            )
+
+        # Handle small images (≤100px) - generate 2x for high-DPI displays
+        if width_int <= 100:
+            # Add 2x version for high-DPI displays to prevent pixelation
+            srcset.append(create_srcset_url(width_int * 2, cloudinary_options))
+        else:
+            # Handle larger images with standard responsive widths
             max_srcset_width = max(srcset_widths)
             if hi_def:
                 max_width_limit = min(width_int * 2, max_srcset_width)
             else:
                 max_width_limit = min(width_int, max_srcset_width)
-
-            def create_srcset_url(width, options):
-                width_options = options.copy()
-                width_options.append(f"w_{width}")
-                width_attrs = ",".join(width_options)
-                return (
-                    f"{cloudinary_url_base}/{width_attrs}/"
-                    f"{encoded_url} {width}w"
-                )
 
             # Generate srcset entries for standard widths
             filtered_widths = [

--- a/canonicalwebteam/image_template/__init__.py
+++ b/canonicalwebteam/image_template/__init__.py
@@ -100,7 +100,8 @@ def image_template(
     image_srcset = ""
     if generate_srcset:
         if srcset_widths is None:
-            srcset_widths = [460, 620, 1036, 1681]
+            # https://vanillaframework.io/docs/settings/breakpoint-settings
+            srcset_widths = [460, 620, 1036, 1681, 1920]
 
         width_int = int(width)
         srcset = []

--- a/canonicalwebteam/image_template/__init__.py
+++ b/canonicalwebteam/image_template/__init__.py
@@ -48,6 +48,30 @@ def image_template(
 
     url_parts = urlparse(url)
 
+    # Check if the image is a format that doesn't need Cloudinary optimization
+    # SVG: Vector format, converting to WebP makes it blurry
+    # WebP/AVIF: Already optimized modern formats
+    # GIF: Animation would be lost in conversion
+    bypass_extensions = ('.svg', '.webp', '.avif', '.gif')
+    if url_parts.path.lower().endswith(bypass_extensions):
+        image_attrs = {
+            "src": url,
+            "alt": alt,
+            "width": int(width),
+            "height": height,
+            "loading": loading,
+            "attrs": attrs,
+        }
+
+        if output_mode == "html":
+            return template.render(**image_attrs)
+        elif output_mode == "attrs":
+            merged_attrs = {**image_attrs, **attrs}
+            del merged_attrs["attrs"]
+            return merged_attrs
+        else:
+            raise ValueError("output_mode must be 'html' or 'attrs'")
+
     # Default cloudinary optimisations
     # https://cloudinary.com/documentation/image_transformations
     cloudinary_options = [

--- a/canonicalwebteam/image_template/__init__.py
+++ b/canonicalwebteam/image_template/__init__.py
@@ -114,8 +114,8 @@ def image_template(
                 f"{encoded_url} {width}w"
             )
 
-        # Handle small images (≤100px) - generate 2x for high-DPI displays
-        if width_int <= 100:
+        # Handle small images (≤460px) - generate 2x for high-DPI displays
+        if width_int <= 460:
             # Add 2x version for high-DPI displays to prevent pixelation
             srcset.append(create_srcset_url(width_int * 2, cloudinary_options))
         else:

--- a/canonicalwebteam/image_template/__init__.py
+++ b/canonicalwebteam/image_template/__init__.py
@@ -52,13 +52,13 @@ def image_template(
         raise Exception("url must contain a hostname")
 
     # Determine format based on file extension and fmt parameter
-    file_extension = url_parts.path.lower().split('.')[-1]
+    file_extension = url_parts.path.lower().split(".")[-1]
 
     # Set format based on file type, using fmt parameter if provided
-    if file_extension == 'svg':
+    if file_extension == "svg":
         format_param = "f_svg" if fmt == "auto" else f"f_{fmt}"
         generate_srcset = False
-    elif file_extension in ['webp', 'avif']:
+    elif file_extension in ["webp", "avif"]:
         format_param = f"f_{file_extension}" if fmt == "auto" else f"f_{fmt}"
         generate_srcset = True
     else:
@@ -129,14 +129,19 @@ def image_template(
 
             # Generate srcset entries for standard widths
             filtered_widths = [
-                w for w in srcset_widths if w <= max_width_limit]
+                w for w in srcset_widths if w <= max_width_limit
+            ]
             srcset.extend(
-                create_srcset_url(w, cloudinary_options) for w in filtered_widths
+                create_srcset_url(w, cloudinary_options)
+                for w in filtered_widths
             )
 
             # Add original width if needed
             existing_widths = {int(w) for w in filtered_widths}
-            if width_int <= max_width_limit and width_int not in existing_widths:
+            if (
+                width_int <= max_width_limit
+                and width_int not in existing_widths
+            ):
                 srcset.append(create_srcset_url(width_int, cloudinary_options))
 
         image_srcset = ", ".join(srcset)

--- a/canonicalwebteam/image_template/__init__.py
+++ b/canonicalwebteam/image_template/__init__.py
@@ -47,55 +47,42 @@ def image_template(
     """
 
     url_parts = urlparse(url)
-
-    # Check if the image is a format that doesn't need Cloudinary optimization
-    # SVG: Vector format, converting to WebP makes it blurry
-    # WebP/AVIF: Already optimized modern formats
-    # GIF: Animation would be lost in conversion
-    bypass_extensions = ('.svg', '.webp', '.avif', '.gif')
-    if url_parts.path.lower().endswith(bypass_extensions):
-        image_attrs = {
-            "src": url,
-            "alt": alt,
-            "width": int(width),
-            "height": height,
-            "loading": loading,
-            "attrs": attrs,
-        }
-
-        if output_mode == "html":
-            return template.render(**image_attrs)
-        elif output_mode == "attrs":
-            merged_attrs = {**image_attrs, **attrs}
-            del merged_attrs["attrs"]
-            return merged_attrs
-        else:
-            raise ValueError("output_mode must be 'html' or 'attrs'")
-
-    # Default cloudinary optimisations
-    # https://cloudinary.com/documentation/image_transformations
-    cloudinary_options = [
-        "f_" + str(fmt),
-        "q_auto",  # Auto optimise quality
-        "fl_sanitize",  # Sanitize SVG content
-    ]
-
-    if e_sharpen:
-        cloudinary_options.append("e_sharpen")
-
-    # If the original image does not match the requested
-    # ratio set crop and fill see
-    # https://cloudinary.com/documentation/image_transformation_reference#crop_parameter
-    if fill:
-        cloudinary_options.append("c_fill")
-
+    
     if not url_parts.netloc:
         raise Exception("url must contain a hostname")
-
+    
+    # Determine format based on file extension and fmt parameter
+    file_extension = url_parts.path.lower().split('.')[-1]
+    
+    # Set format based on file type, using fmt parameter if provided
+    if file_extension == 'svg':
+        format_param = "f_svg" if fmt == "auto" else f"f_{fmt}"
+        generate_srcset = False
+    elif file_extension in ['webp', 'avif']:
+        format_param = f"f_{file_extension}" if fmt == "auto" else f"f_{fmt}"
+        generate_srcset = True
+    else:
+        format_param = f"f_{fmt}"
+        generate_srcset = True
+    
+    # Build cloudinary options
+    cloudinary_options = [
+        format_param,
+        "q_auto",  # Auto optimise quality
+        "fl_sanitize",  # Sanitize content
+    ]
+    
+    if e_sharpen:
+        cloudinary_options.append("e_sharpen")
+    
+    if fill:
+        cloudinary_options.append("c_fill")
+    
+    # Create main image source
     std_def_cloudinary_options = cloudinary_options.copy()
-    std_def_cloudinary_options.append("w_" + str(width))
+    std_def_cloudinary_options.append(f"w_{width}")
     std_def_cloudinary_attrs = ",".join(std_def_cloudinary_options)
-
+    
     # Decode the URL first to prevent double encoding
     decoded_url = unquote(url)
     encoded_url = quote(decoded_url, safe="")
@@ -104,68 +91,68 @@ def image_template(
         f"{std_def_cloudinary_attrs}/"
         f"{encoded_url}"
     )
-
-    # Generate srcset values with optimized logic for real-world usage
-    # https://vanillaframework.io/docs/settings/breakpoint-settings
-    if srcset_widths is None:
-        srcset_widths = [460, 620, 1036, 1681]
-
-    width_int = int(width)
-    srcset = []
-
-    # Only generate srcset for images larger than 100px to avoid
-    # unnecessary overhead
-    if width_int > 100:
-        max_srcset_width = max(srcset_widths)
-        # When hi_def is enabled, allow slightly larger for high-DPI
-        # But cap at 2x to avoid excessive payload
-        if hi_def:
-            max_width_limit = min(width_int * 2, max_srcset_width)
-        else:
-            max_width_limit = min(width_int, max_srcset_width)
-
-        def create_srcset_url(width, options):
-            width_options = options.copy()
-            width_options.append(f"w_{width}")
-            width_attrs = ",".join(width_options)
-            return (
-                f"{cloudinary_url_base}/{width_attrs}/"
-                f"{encoded_url} {width}w"
+    
+    # Generate srcset if needed
+    image_srcset = ""
+    if generate_srcset:
+        if srcset_widths is None:
+            srcset_widths = [460, 620, 1036, 1681]
+        
+        width_int = int(width)
+        srcset = []
+        
+        # Only generate srcset for images larger than 100px
+        if width_int > 100:
+            max_srcset_width = max(srcset_widths)
+            if hi_def:
+                max_width_limit = min(width_int * 2, max_srcset_width)
+            else:
+                max_width_limit = min(width_int, max_srcset_width)
+            
+            def create_srcset_url(width, options):
+                width_options = options.copy()
+                width_options.append(f"w_{width}")
+                width_attrs = ",".join(width_options)
+                return (
+                    f"{cloudinary_url_base}/{width_attrs}/"
+                    f"{encoded_url} {width}w"
+                )
+            
+            # Generate srcset entries for standard widths
+            filtered_widths = [w for w in srcset_widths if w <= max_width_limit]
+            srcset.extend(
+                create_srcset_url(w, cloudinary_options) for w in filtered_widths
             )
-
-        # Generate srcset entries for standard widths
-        filtered_widths = [w for w in srcset_widths if w <= max_width_limit]
-        srcset.extend(
-            create_srcset_url(w, cloudinary_options) for w in filtered_widths
-        )
-
-        # Add original width if needed
-        existing_widths = {int(w) for w in filtered_widths}
-        if width_int <= max_width_limit and width_int not in existing_widths:
-            srcset.append(create_srcset_url(width_int, cloudinary_options))
-
-    image_srcset = ", ".join(srcset)
-
+            
+            # Add original width if needed
+            existing_widths = {int(w) for w in filtered_widths}
+            if width_int <= max_width_limit and width_int not in existing_widths:
+                srcset.append(create_srcset_url(width_int, cloudinary_options))
+        
+        image_srcset = ", ".join(srcset)
+    
+    # Format sizes attribute
     try:
         sizes = sizes.format(width, width)
     except (IndexError, KeyError):
         pass
-
+    
+    # Build image attributes
     image_attrs = {
         "src": image_src,
-        "srcset": image_srcset,
-        "sizes": sizes,
         "alt": alt,
         "width": int(width),
         "height": height,
         "loading": loading,
         "attrs": attrs,
     }
-
-    if not image_srcset:
-        del image_attrs["srcset"]
-        del image_attrs["sizes"]
-
+    
+    # Add srcset and sizes if generated
+    if image_srcset:
+        image_attrs["srcset"] = image_srcset
+        image_attrs["sizes"] = sizes
+    
+    # Return based on output mode
     if output_mode == "html":
         return template.render(**image_attrs)
     elif output_mode == "attrs":

--- a/canonicalwebteam/image_template/__init__.py
+++ b/canonicalwebteam/image_template/__init__.py
@@ -116,6 +116,7 @@ def image_template(
 
         # Handle small images (≤460px) - generate 2x for high-DPI displays
         if width_int <= 460:
+            srcset.append(create_srcset_url(width_int, cloudinary_options))
             # Add 2x version for high-DPI displays to prevent pixelation
             srcset.append(create_srcset_url(width_int * 2, cloudinary_options))
         else:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="canonicalwebteam.image-template",
-    version="1.8.0",
+    version="1.9.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(

--- a/tests/test_image_template.py
+++ b/tests/test_image_template.py
@@ -157,7 +157,7 @@ class TestImageTemplate(unittest.TestCase):
         self.assertNotIn("1036w", markup)
 
     def test_small_images_generate_2x_srcset(self):
-        """Test that small images (≤100px) generate 2x srcset for high-DPI displays"""
+        """Test that small images (≤460px) generate 2x srcset for high-DPI displays"""
         html_result = image_template(
             url="https://example.com/image.jpg",
             alt="Test Image",
@@ -277,19 +277,19 @@ class TestImageTemplate(unittest.TestCase):
                 self.assertIn("q_auto", attrs_result["src"])
                 self.assertIn("fl_sanitize", attrs_result["src"])
                 self.assertIn("w_500", attrs_result["src"])
-                
+
                 # Should have srcset for images > 100px
                 self.assertIn("srcset", attrs_result)
                 self.assertIn("res.cloudinary.com", attrs_result["srcset"])
                 self.assertIn(expected_format, attrs_result["srcset"])
-                
+
                 # Should have sizes attribute
                 self.assertIn("sizes", attrs_result)
 
     def test_webp_avif_with_fill_and_sharpen(self):
         """Test that WebP and AVIF files respect fill and sharpen parameters"""
         test_url = "https://example.com/image.webp"
-        
+
         attrs_result = image_template(
             url=test_url,
             alt="Test Image",
@@ -309,7 +309,7 @@ class TestImageTemplate(unittest.TestCase):
     def test_svg_uses_cloudinary_with_f_svg(self):
         """Test that SVG files use Cloudinary with f_svg format and no srcset"""
         svg_url = "https://assets.ubuntu.com/v1/450d7c2f-openstack-hero.svg"
-        
+
         # Test HTML output
         html_result = image_template(
             url=svg_url,
@@ -348,7 +348,7 @@ class TestImageTemplate(unittest.TestCase):
     def test_svg_with_fill_and_sharpen(self):
         """Test that SVG files respect fill and e_sharpen parameters"""
         svg_url = "https://assets.ubuntu.com/v1/450d7c2f-openstack-hero.svg"
-        
+
         attrs_result = image_template(
             url=svg_url,
             alt="Test SVG",

--- a/tests/test_image_template.py
+++ b/tests/test_image_template.py
@@ -157,12 +157,12 @@ class TestImageTemplate(unittest.TestCase):
         self.assertNotIn("1036w", markup)
 
     def test_small_images_generate_2x_srcset(self):
-        """Test that small images (≤460px) generate 2x srcset for high-DPI displays"""
+        """Test that small images (≤460px) generate 2x srcset"""
         html_result = image_template(
             url="https://example.com/image.jpg",
             alt="Test Image",
             width="50",
-            height="50"
+            height="50",
         )
 
         # Should contain srcset with 2x version
@@ -174,7 +174,7 @@ class TestImageTemplate(unittest.TestCase):
             alt="Test Image",
             width="50",
             height="50",
-            output_mode="attrs"
+            output_mode="attrs",
         )
 
         # Should have srcset with 2x version
@@ -254,10 +254,11 @@ class TestImageTemplate(unittest.TestCase):
     # GIF handling removed as requested
 
     def test_webp_avif_use_cloudinary_with_srcset(self):
-        """Test that WebP and AVIF files use Cloudinary with format preservation and srcset"""
+        # Test that WebP and AVIF files use Cloudinary
+        # with format preservation and srcset
         test_cases = [
             ("https://example.com/image.webp", "f_webp"),
-            ("https://example.com/image.avif", "f_avif")
+            ("https://example.com/image.avif", "f_avif"),
         ]
 
         for test_url, expected_format in test_cases:
@@ -268,7 +269,7 @@ class TestImageTemplate(unittest.TestCase):
                     alt="Test Image",
                     width="500",
                     height="300",
-                    output_mode="attrs"
+                    output_mode="attrs",
                 )
 
                 # Should use Cloudinary URL with format preservation
@@ -297,7 +298,7 @@ class TestImageTemplate(unittest.TestCase):
             height="200",
             fill=True,
             e_sharpen=True,
-            output_mode="attrs"
+            output_mode="attrs",
         )
 
         # Should include fill and sharpen in both src and srcset
@@ -307,15 +308,12 @@ class TestImageTemplate(unittest.TestCase):
         self.assertIn("e_sharpen", attrs_result["srcset"])
 
     def test_svg_uses_cloudinary_with_f_svg(self):
-        """Test that SVG files use Cloudinary with f_svg format and no srcset"""
+        """Test that SVGs use Cloudinary with f_svg format and no srcset"""
         svg_url = "https://assets.ubuntu.com/v1/450d7c2f-openstack-hero.svg"
 
         # Test HTML output
         html_result = image_template(
-            url=svg_url,
-            alt="Test SVG",
-            width="200",
-            height="100"
+            url=svg_url, alt="Test SVG", width="200", height="100"
         )
 
         # Should use Cloudinary with f_svg
@@ -331,7 +329,7 @@ class TestImageTemplate(unittest.TestCase):
             alt="Test SVG",
             width="200",
             height="100",
-            output_mode="attrs"
+            output_mode="attrs",
         )
 
         # Should have Cloudinary URL with f_svg
@@ -356,7 +354,7 @@ class TestImageTemplate(unittest.TestCase):
             height="100",
             fill=True,
             e_sharpen=True,
-            output_mode="attrs"
+            output_mode="attrs",
         )
 
         # Should include fill and sharpen parameters

--- a/tests/test_image_template.py
+++ b/tests/test_image_template.py
@@ -222,11 +222,11 @@ class TestImageTemplate(unittest.TestCase):
             f"{encoded_asset_url}"
         )
 
-        srcset_widths = [460, 620, 1036, 1681]
+        srcset_widths = [460, 620, 1036, 1681, 1920]
         srcset = []
         width = image_attrs["width"]
 
-        max_width_limit = min(width, 1681)
+        max_width_limit = min(width, 1920)
         for srcset_width in srcset_widths:
             if srcset_width <= max_width_limit:
                 srcset.append(

--- a/tests/test_image_template.py
+++ b/tests/test_image_template.py
@@ -156,12 +156,30 @@ class TestImageTemplate(unittest.TestCase):
         self.assertNotIn("620w", markup)
         self.assertNotIn("1036w", markup)
 
-    def test_no_srcset_for_small_images(self):
-        # Test with image smaller than 100px threshold
-        markup = image_template(url=non_asset_url, alt="test", width="80")
+    def test_small_images_generate_2x_srcset(self):
+        """Test that small images (≤100px) generate 2x srcset for high-DPI displays"""
+        html_result = image_template(
+            url="https://example.com/image.jpg",
+            alt="Test Image",
+            width="50",
+            height="50"
+        )
 
-        self.assertNotIn("srcset=", markup)
-        self.assertNotIn("sizes=", markup)
+        # Should contain srcset with 2x version
+        self.assertIn("srcset", html_result)
+        self.assertIn("100w", html_result)  # 2x the original 50px width
+
+        attrs_result = image_template(
+            url="https://example.com/image.jpg",
+            alt="Test Image",
+            width="50",
+            height="50",
+            output_mode="attrs"
+        )
+
+        # Should have srcset with 2x version
+        self.assertIn("srcset", attrs_result)
+        self.assertIn("100w", attrs_result["srcset"])
 
     def test_srcset_for_medium_images(self):
         # Test with image larger than 100px threshold

--- a/tests/test_image_template.py
+++ b/tests/test_image_template.py
@@ -233,6 +233,50 @@ class TestImageTemplate(unittest.TestCase):
 
         self.assertEqual(expected_attrs, returned_attrs)
 
+    def test_optimized_formats_bypass_cloudinary(self):
+        """Test that optimized formats bypass Cloudinary processing"""
+        test_urls = [
+            "https://assets.ubuntu.com/v1/450d7c2f-openstack-hero.svg",
+            "https://example.com/image.webp",
+            "https://example.com/image.avif",
+            "https://example.com/animation.gif"
+        ]
+
+        for test_url in test_urls:
+            with self.subTest(url=test_url):
+                # Test HTML output
+                html_result = image_template(
+                    url=test_url,
+                    alt="Test Image",
+                    width="200",
+                    height="100"
+                )
+
+                # Should use original URL, not Cloudinary
+                self.assertIn(test_url, html_result)
+                self.assertNotIn("res.cloudinary.com", html_result)
+                self.assertNotIn("srcset", html_result)
+
+                # Test attrs output
+                attrs_result = image_template(
+                    url=test_url,
+                    alt="Test Image",
+                    width="200",
+                    height="100",
+                    output_mode="attrs"
+                )
+
+                expected_attrs = {
+                    "src": test_url,
+                    "alt": "Test Image",
+                    "width": 200,
+                    "height": "100",
+                    "loading": "lazy"
+                }
+
+                self.assertEqual(expected_attrs, attrs_result)
+                self.assertNotIn("srcset", attrs_result)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem
SVG images and other already-optimized formats (WebP, AVIF) were being processed through Cloudinary, which:

- Converts SVGs to WebP, making them blurry and losing vector scalability
- Unnecessarily processes already-optimized modern formats like WebP and AVIF

## Key Changes
### Format-Specific Handling
- SVG files : Now use f_svg format when fmt="auto" and skip srcset generation (as vector graphics don't need responsive sizing)
- WebP/AVIF files : Preserve original format ( f_webp / f_avif ) when fmt="auto" while generating responsive srcset
- Other formats : Continue using the specified fmt parameter with full srcset support
### High-DPI Support for Small Images
- Images ≤100px now generate a 2x srcset entry to prevent pixelation on high-DPI displays
- Particularly beneficial for logos, icons, and other small graphics that appear blurry on retina displays

## QA
- Check the demo link
- https://ubuntu-com-15564.demos.haus/hpc
- Scroll to the 'Solutions for HPC' section and see that images are not pixelated. Compare that with production https://ubuntu.com/hpc